### PR TITLE
Persistent task management

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "indexer",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "scripts": {
     "clean:dist": "rimraf dist/*",
     "build": "npm run clean:dist && tsc && cp package.json dist",

--- a/src/rest-api/items-query.ts
+++ b/src/rest-api/items-query.ts
@@ -17,12 +17,12 @@
 import { inject } from 'inversify';
 import { controller, httpGet, queryParam, BaseHttpController } from 'inversify-express-utils';
 import { interfaces } from 'inversify-express-utils/dts/interfaces';
-import { PersistentStorage, TYPES } from '../types';
+import { ItemStorage, TYPES } from '../types';
 
 @controller('/item')
 export class ItemsQuery<T> extends BaseHttpController {
 
-    constructor(@inject(TYPES.PersistentStorage) private _storage: PersistentStorage<T>) {
+    constructor(@inject(TYPES.ItemStorage) private _storage: ItemStorage<T>) {
         super();
     }
 

--- a/src/scraper/abstract/base-scraper.ts
+++ b/src/scraper/abstract/base-scraper.ts
@@ -26,7 +26,6 @@ import { ConfigLoader, ItemStorage, Scraper } from '../../types';
 @injectable()
 export abstract class BaseScraper<T> implements Scraper {
     protected className: string;
-    protected _taskRetriedTimes: Map<number, number>;
 
     protected constructor(protected _taskOrchestra: TaskOrchestra,
                           protected _config: ConfigLoader,

--- a/src/scraper/abstract/base-scraper.ts
+++ b/src/scraper/abstract/base-scraper.ts
@@ -20,7 +20,7 @@ import { MainTask } from '../../task/main-task';
 import { SubTask } from '../../task/sub-task';
 import { TaskOrchestra } from '../../task/task-orchestra';
 import { Task, TaskType } from '../../task/task-types';
-import { ConfigLoader, PersistentStorage, Scraper } from '../../types';
+import { ConfigLoader, ItemStorage, Scraper } from '../../types';
 import { captureMessage } from '../../utils/sentry';
 
 const MAX_TASK_RETRIED_TIMES = 10;
@@ -32,7 +32,7 @@ export abstract class BaseScraper<T> implements Scraper {
 
     protected constructor(protected _taskOrchestra: TaskOrchestra,
                           protected _config: ConfigLoader,
-                          protected _store: PersistentStorage<T>) {
+                          protected _store: ItemStorage<T>) {
         this.className = this.constructor.name;
     }
 

--- a/src/scraper/bangumi-moe.ts
+++ b/src/scraper/bangumi-moe.ts
@@ -35,7 +35,6 @@ export class BangumiMoe extends BaseScraper<string> {
                 @inject(TYPES.ConfigLoader) config: ConfigLoader,
                 @inject(TaskOrchestra) taskOrchestra: TaskOrchestra) {
         super(taskOrchestra, config, store);
-        this._taskRetriedTimes = new Map<number, number>();
     }
 
     public async executeMainTask(pageNo: number = 1): Promise<{items: Array<Item<string>>, hasNext: boolean}> {

--- a/src/scraper/bangumi-moe.ts
+++ b/src/scraper/bangumi-moe.ts
@@ -23,7 +23,7 @@ import { MediaFile } from '../entity/media-file';
 import { Publisher } from '../entity/publisher';
 import { Team } from '../entity/Team';
 import { TaskOrchestra } from '../task/task-orchestra';
-import { ConfigLoader, PersistentStorage, TYPES } from '../types';
+import { ConfigLoader, ItemStorage, TYPES } from '../types';
 import { captureException } from '../utils/sentry';
 import { BaseScraper } from './abstract/base-scraper';
 
@@ -31,7 +31,7 @@ import { BaseScraper } from './abstract/base-scraper';
 export class BangumiMoe extends BaseScraper<string> {
     private static _host = 'https://bangumi.moe';
 
-    constructor(@inject(TYPES.PersistentStorage) store: PersistentStorage<string>,
+    constructor(@inject(TYPES.ItemStorage) store: ItemStorage<string>,
                 @inject(TYPES.ConfigLoader) config: ConfigLoader,
                 @inject(TaskOrchestra) taskOrchestra: TaskOrchestra) {
         super(taskOrchestra, config, store);

--- a/src/scraper/dmhy.ts
+++ b/src/scraper/dmhy.ts
@@ -24,7 +24,7 @@ import { MediaFile } from '../entity/media-file';
 import { Publisher } from '../entity/publisher';
 import { Team } from '../entity/Team';
 import { TaskOrchestra } from '../task/task-orchestra';
-import { ConfigLoader, PersistentStorage, TYPES } from '../types';
+import { ConfigLoader, ItemStorage, TYPES } from '../types';
 import { toUTCDate, trimDomain } from '../utils/normalize';
 import { captureException } from '../utils/sentry';
 import { BaseScraper } from './abstract/base-scraper';
@@ -73,7 +73,7 @@ export class DmhyScraper extends BaseScraper<number> {
     private static _host = 'https://share.dmhy.org';
     private _browser: Browser;
 
-    constructor(@inject(TYPES.PersistentStorage) store: PersistentStorage<number>,
+    constructor(@inject(TYPES.ItemStorage) store: ItemStorage<number>,
                 @inject(TaskOrchestra) taskOrchestra: TaskOrchestra,
                 @inject(TYPES.ConfigLoader) config: ConfigLoader) {
         super(taskOrchestra, config, store);

--- a/src/scraper/dmhy.ts
+++ b/src/scraper/dmhy.ts
@@ -77,7 +77,6 @@ export class DmhyScraper extends BaseScraper<number> {
                 @inject(TaskOrchestra) taskOrchestra: TaskOrchestra,
                 @inject(TYPES.ConfigLoader) config: ConfigLoader) {
         super(taskOrchestra, config, store);
-        this._taskRetriedTimes = new Map<number, number>();
     }
 
     public async start(): Promise<any> {

--- a/src/scraper/nyaa.ts
+++ b/src/scraper/nyaa.ts
@@ -22,7 +22,7 @@ import { ItemType } from '../entity/item-type';
 import { MediaFile } from '../entity/media-file';
 import { Publisher } from '../entity/publisher';
 import { TaskOrchestra } from '../task/task-orchestra';
-import { ConfigLoader, PersistentStorage, TYPES } from '../types';
+import { ConfigLoader, ItemStorage, TYPES } from '../types';
 import { captureException } from '../utils/sentry';
 import { BaseScraper } from './abstract/base-scraper';
 import cheerio = require('cheerio');
@@ -32,7 +32,7 @@ export class NyaaScraper extends BaseScraper<number> {
     private static _host = 'https://nyaa.si';
 
     constructor(
-        @inject(TYPES.PersistentStorage) store: PersistentStorage<number>,
+        @inject(TYPES.ItemStorage) store: ItemStorage<number>,
         @inject(TaskOrchestra) taskOrchestra: TaskOrchestra,
         @inject(TYPES.ConfigLoader) config: ConfigLoader
     ) {

--- a/src/scraper/nyaa.ts
+++ b/src/scraper/nyaa.ts
@@ -37,7 +37,6 @@ export class NyaaScraper extends BaseScraper<number> {
         @inject(TYPES.ConfigLoader) config: ConfigLoader
     ) {
         super(taskOrchestra, config, store);
-        this._taskRetriedTimes = new Map<number, number>();
     }
 
     public async executeMainTask(pageNo?: number): Promise<{ items: Array<Item<number>>, hasNext: boolean }> {

--- a/src/service/database-service.ts
+++ b/src/service/database-service.ts
@@ -18,29 +18,55 @@ import { inject, injectable } from 'inversify';
 import { Db, MongoClient } from 'mongodb';
 import { ConfigLoader, TYPES } from '../types';
 
+type Func = () => void;
+
 @injectable()
 export class DatabaseService {
 
     private _db: Db;
     private _client: MongoClient;
+    private onStartCallbacks: Array<{callback: Func, context: any}>;
+
+    public get isStarted(): boolean {
+        return this._client.isConnected();
+    }
 
     public get db(): Db {
         return this._db;
     }
 
     constructor(@inject(TYPES.ConfigLoader) private _config: ConfigLoader) {
+        this.onStartCallbacks = [];
     }
 
     public async onEnd(): Promise<void> {
         await this._client.close();
+        for (let i = 0; i < this.onStartCallbacks.length; i++) {
+            this.onStartCallbacks[i].context = null;
+            this.onStartCallbacks[i].callback = null;
+            this.onStartCallbacks[i] = null;
+        }
     }
 
     public async onStart(): Promise<void> {
+        if (this.isStarted) {
+            return;
+        }
         const url = `mongodb://${this._config.dbUser}:${this._config.dbPass}@${
             this._config.dbHost
             }:${this._config.dbPort}?authSource=${this._config.authSource}`;
         this._client = await MongoClient.connect(url, { useNewUrlParser: true, useUnifiedTopology: true });
         this._db = this._client.db(this._config.dbName);
+        for (let callbackWrapper of this.onStartCallbacks) {
+            callbackWrapper.callback.call(callbackWrapper.context);
+        }
         return Promise.resolve();
+    }
+
+    public addOnStartCallback(context: any, callback: () => void) {
+        this.onStartCallbacks.push({
+            callback,
+            context
+        });
     }
 }

--- a/src/service/database-service.ts
+++ b/src/service/database-service.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 IROHA LAB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { inject, injectable } from 'inversify';
+import { Db, MongoClient } from 'mongodb';
+import { ConfigLoader, TYPES } from '../types';
+
+@injectable()
+export class DatabaseService {
+
+    private _db: Db;
+    private _client: MongoClient;
+
+    public get db(): Db {
+        return this._db;
+    }
+
+    constructor(@inject(TYPES.ConfigLoader) private _config: ConfigLoader) {
+    }
+
+    public async onEnd(): Promise<void> {
+        await this._client.close();
+    }
+
+    public async onStart(): Promise<void> {
+        const url = `mongodb://${this._config.dbUser}:${this._config.dbPass}@${
+            this._config.dbHost
+            }:${this._config.dbPort}?authSource=${this._config.authSource}`;
+        this._client = await MongoClient.connect(url, { useNewUrlParser: true, useUnifiedTopology: true });
+        this._db = this._client.db(this._config.dbName);
+        return Promise.resolve();
+    }
+}

--- a/src/storage/mongodb-item-store.ts
+++ b/src/storage/mongodb-item-store.ts
@@ -24,13 +24,14 @@ import { escapeRegExp } from '../utils/normalize';
 @injectable()
 export class MongodbItemStore<T> implements ItemStorage<T> {
 
-    private _db: Db;
+    private get db(): Db {
+        return this._databaseService.db;
+    }
 
     private _collectionName: string = 'items';
 
     constructor(@inject(TYPES.ConfigLoader) private _config: ConfigLoader,
                 private _databaseService: DatabaseService) {
-        this._db = this._databaseService.db;
     }
 
     public deleteItem(id: T): Promise<boolean> {
@@ -46,7 +47,7 @@ export class MongodbItemStore<T> implements ItemStorage<T> {
     }
 
     public async filterItemNotStored(ids: T[]): Promise<T[]> {
-        const cursor = this._db.collection(this._collectionName).find({
+        const cursor = this.db.collection(this._collectionName).find({
             id: {
                 $in: ids
             }
@@ -57,7 +58,7 @@ export class MongodbItemStore<T> implements ItemStorage<T> {
     }
 
     public async putItem(item: Item<T>): Promise<boolean> {
-        await this._db.collection(this._collectionName).insertOne(Object.assign({}, item));
+        await this.db.collection(this._collectionName).insertOne(Object.assign({}, item));
         return Promise.resolve(true);
     }
 
@@ -67,7 +68,7 @@ export class MongodbItemStore<T> implements ItemStorage<T> {
             return Promise.resolve([]);
         }
         let rgx = rgxArr.map(s => escapeRegExp(s)).join('.*?');
-        const cursor = this._db.collection(this._collectionName).find({
+        const cursor = this.db.collection(this._collectionName).find({
             title: {
                 $options: 'i',
                 $regex: rgx

--- a/src/storage/mongodb-task-store.spec.ts
+++ b/src/storage/mongodb-task-store.spec.ts
@@ -34,7 +34,6 @@ export class MongodbItemStoreSpec {
     private _taskCollectionName = 'task';
     private _failedTaskCollectionName = 'failed_task';
 
-
     @SetupFixture
     public setupFixture() {
         if (!process.env.DB_NAME) {

--- a/src/storage/mongodb-task-store.spec.ts
+++ b/src/storage/mongodb-task-store.spec.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2020 IROHA LAB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Expect, Setup, SetupFixture, Teardown, Test, TestFixture } from 'alsatian';
+import { fail } from 'assert';
+import { Container } from 'inversify';
+import { MongoClient } from 'mongodb';
+import { DatabaseService } from '../service/database-service';
+import { CommonTask, TaskType } from '../task/task-types';
+import { FakeConfigManager } from '../test/fake-config';
+import { ConfigLoader, TaskStorage, TYPES } from '../types';
+import { MongodbTaskStore } from './mongodb-task-store';
+
+@TestFixture('MongodbStore test spec')
+export class MongodbItemStoreSpec {
+    private _store: MongodbTaskStore;
+    private _config: ConfigLoader;
+    private _container: Container;
+    private _databaseService: DatabaseService;
+
+    private _taskCollectionName = 'task';
+    private _failedTaskCollectionName = 'failed_task';
+
+
+    @SetupFixture
+    public setupFixture() {
+        if (!process.env.DB_NAME) {
+            fail('You must set the Environment Variable DB_NAME to avoid potential damage to default database');
+        }
+        this._container = new Container();
+        this._container.bind<ConfigLoader>(TYPES.ConfigLoader).to(FakeConfigManager).inSingletonScope();
+        this._container.bind<DatabaseService>(DatabaseService).toSelf().inSingletonScope();
+        this._container.bind<TaskStorage>(TYPES.TaskStorage).to(MongodbTaskStore).inTransientScope();
+        this._config = this._container.get<ConfigLoader>(TYPES.ConfigLoader);
+        this._config.load();
+        // this._config.dbHost = 'mongo';
+        this._config.dbPort = 27017;
+    }
+
+    @Setup
+    public async databaseInit(): Promise<void> {
+        // Cast to PostgresStore<number>
+        this._databaseService = await this._container.get<DatabaseService>(DatabaseService);
+        await this._databaseService.onStart();
+        this._store = this._container.get<TaskStorage>(TYPES.TaskStorage) as MongodbTaskStore;
+    }
+
+    @Teardown
+    public async databaseCleanUp(): Promise<void> {
+        await this._databaseService.onEnd();
+    }
+
+    @Test('Task Queue Operation')
+    public async taskQueueOperation(): Promise<void> {
+        const tasks = [];
+        for (let i = 0; i < 10; i++) {
+            tasks.push(new CommonTask(TaskType.SUB));
+        }
+
+        const promises = [];
+        for (let task of tasks) {
+            promises.push(this._store.enqueueTask(task));
+        }
+        await Promise.all(promises);
+        let idx = 0;
+        while (await this._store.hasTask()) {
+            let task = await this._store.getTask();
+            Expect(task.id).toBe(tasks[idx].id);
+            let sleepTime = Math.round(Math.random() * 5000);
+            await this.sleep(sleepTime);
+            await this._store.cleanTask();
+            idx++;
+        }
+        Expect(await this._store.hasTask()).toBe(false);
+
+        const client = await this._createClient();
+        await client.db(this._config.dbName).collection(this._taskCollectionName).drop();
+    }
+
+    @Test('Failed Task Queue Operation')
+    public async failedTaskQueueOperation(): Promise<void> {
+        const tasks = [];
+        for (let i = 0; i < 10; i++) {
+            tasks.push(new CommonTask(TaskType.SUB));
+        }
+
+        const promises = [];
+        for (let task of tasks) {
+            promises.push(this._store.enqueueFailedTask(task));
+        }
+        await Promise.all(promises);
+        let idx = 0;
+        while (await this._store.hasFailedTask()) {
+            let task = await this._store.getFailedTask();
+            Expect(task.id).toBe(tasks[idx].id);
+            let sleepTime = Math.round(Math.random() * 5000);
+            await this.sleep(sleepTime);
+            await this._store.cleanFailedTask();
+            idx++;
+        }
+        Expect(await this._store.hasFailedTask()).toBe(false);
+
+        const client = await this._createClient();
+        await client.db(this._config.dbName).collection(this._failedTaskCollectionName).drop();
+    }
+
+    private async _createClient(): Promise<MongoClient> {
+        const url = `mongodb://${this._config.dbUser}:${this._config.dbPass}@${
+            this._config.dbHost
+            }:${this._config.dbPort}?authSource=${this._config.authSource}`;
+        return await MongoClient.connect(url, { useNewUrlParser: true, useUnifiedTopology: true });
+    }
+
+    private sleep(milliseconds: number): Promise<void> {
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                resolve();
+            }, milliseconds);
+        });
+    }
+}

--- a/src/storage/mongodb-task-store.spec.ts
+++ b/src/storage/mongodb-task-store.spec.ts
@@ -76,11 +76,10 @@ export class MongodbItemStoreSpec {
         await Promise.all(promises);
         let idx = 0;
         while (await this._store.hasTask()) {
-            let task = await this._store.getTask();
+            let task = await this._store.popTask();
             Expect(task.id).toBe(tasks[idx].id);
             let sleepTime = Math.round(Math.random() * 5000);
             await this.sleep(sleepTime);
-            await this._store.cleanTask();
             idx++;
         }
         Expect(await this._store.hasTask()).toBe(false);
@@ -103,11 +102,10 @@ export class MongodbItemStoreSpec {
         await Promise.all(promises);
         let idx = 0;
         while (await this._store.hasFailedTask()) {
-            let task = await this._store.getFailedTask();
+            let task = await this._store.popFailedTask();
             Expect(task.id).toBe(tasks[idx].id);
             let sleepTime = Math.round(Math.random() * 5000);
             await this.sleep(sleepTime);
-            await this._store.cleanFailedTask();
             idx++;
         }
         Expect(await this._store.hasFailedTask()).toBe(false);

--- a/src/storage/mongodb-task-store.spec.ts
+++ b/src/storage/mongodb-task-store.spec.ts
@@ -71,12 +71,12 @@ export class MongodbItemStoreSpec {
 
         const promises = [];
         for (let task of tasks) {
-            promises.push(this._store.enqueueTask(task));
+            promises.push(this._store.offerTask(task));
         }
         await Promise.all(promises);
         let idx = 0;
         while (await this._store.hasTask()) {
-            let task = await this._store.popTask();
+            let task = await this._store.pollTask();
             Expect(task.id).toBe(tasks[idx].id);
             let sleepTime = Math.round(Math.random() * 5000);
             await this.sleep(sleepTime);
@@ -97,13 +97,14 @@ export class MongodbItemStoreSpec {
 
         const promises = [];
         for (let task of tasks) {
-            promises.push(this._store.enqueueFailedTask(task));
+            promises.push(this._store.offerFailedTask(task));
         }
         await Promise.all(promises);
         let idx = 0;
         while (await this._store.hasFailedTask()) {
-            let task = await this._store.popFailedTask();
+            let task = await this._store.pollFailedTask();
             Expect(task.id).toBe(tasks[idx].id);
+            Expect(task.retryCount).toBeGreaterThan(0);
             let sleepTime = Math.round(Math.random() * 5000);
             await this.sleep(sleepTime);
             idx++;

--- a/src/storage/mongodb-task-store.spec.ts
+++ b/src/storage/mongodb-task-store.spec.ts
@@ -69,16 +69,15 @@ export class MongodbItemStoreSpec {
             tasks.push(new CommonTask(TaskType.SUB));
         }
 
-        const promises = [];
         for (let task of tasks) {
-            promises.push(this._store.offerTask(task));
+            await this._store.offerTask(task);
         }
-        await Promise.all(promises);
+
         let idx = 0;
         while (await this._store.hasTask()) {
             let task = await this._store.pollTask();
             Expect(task.id).toBe(tasks[idx].id);
-            let sleepTime = Math.round(Math.random() * 5000);
+            let sleepTime = Math.round(Math.random() * 20);
             await this.sleep(sleepTime);
             idx++;
         }
@@ -95,17 +94,16 @@ export class MongodbItemStoreSpec {
             tasks.push(new CommonTask(TaskType.SUB));
         }
 
-        const promises = [];
         for (let task of tasks) {
-            promises.push(this._store.offerFailedTask(task));
+            await this._store.offerFailedTask(task);
         }
-        await Promise.all(promises);
+
         let idx = 0;
         while (await this._store.hasFailedTask()) {
             let task = await this._store.pollFailedTask();
             Expect(task.id).toBe(tasks[idx].id);
             Expect(task.retryCount).toBeGreaterThan(0);
-            let sleepTime = Math.round(Math.random() * 5000);
+            let sleepTime = Math.round(Math.random() * 20);
             await this.sleep(sleepTime);
             idx++;
         }

--- a/src/storage/mongodb-task-store.ts
+++ b/src/storage/mongodb-task-store.ts
@@ -48,6 +48,7 @@ export class MongodbTaskStore implements TaskStorage {
     }
 
     public enqueueFailedTask(task: Task): Promise<boolean> {
+        task.retryCount = task.retryCount ? task.retryCount++ : 1;
         return this.push(this._failedTaskCollectionName, task);
     }
 

--- a/src/storage/mongodb-task-store.ts
+++ b/src/storage/mongodb-task-store.ts
@@ -33,8 +33,10 @@ export class MongodbTaskStore implements TaskStorage {
     constructor(private _databaseService: DatabaseService) {
     }
 
-    public pollFailedTask(): Promise<Task> {
-        return this.poll(this._failedTaskCollectionName);
+    public async pollFailedTask(): Promise<Task> {
+        let task = await this.poll(this._failedTaskCollectionName);
+        task.retryCount = task.retryCount ? task.retryCount++ : 1;
+        return task;
     }
 
     public pollTask(): Promise<Task> {
@@ -42,7 +44,6 @@ export class MongodbTaskStore implements TaskStorage {
     }
 
     public offerFailedTask(task: Task): Promise<boolean> {
-        task.retryCount = task.retryCount ? task.retryCount++ : 1;
         return this.push(this._failedTaskCollectionName, task);
     }
 

--- a/src/storage/mongodb-task-store.ts
+++ b/src/storage/mongodb-task-store.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 IROHA LAB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { injectable } from 'inversify';
+import { Db } from 'mongodb';
+import { DatabaseService } from '../service/database-service';
+import { Task } from '../task/task-types';
+import { TaskStorage } from '../types';
+
+@injectable()
+export class MongodbTaskStore implements TaskStorage {
+
+    private _db: Db;
+    private _taskCollectionName = 'task';
+    private _failedTaskCollectionName = 'failed_task';
+
+    constructor(private _databaseService: DatabaseService) {
+        this._db = this._databaseService.db;
+    }
+
+    public getFailedTask(): Promise<Task> {
+        return this.peek(this._failedTaskCollectionName);
+    }
+
+    public getTask(): Promise<Task> {
+        return this.peek(this._taskCollectionName);
+    }
+
+    public enqueueFailedTask(task: Task): Promise<boolean> {
+        return this.push(this._failedTaskCollectionName, task);
+    }
+
+    public enqueueTask(task: Task): Promise<boolean> {
+        return this.push(this._taskCollectionName, task);
+    }
+
+    public cleanFailedTask(): Promise<boolean> {
+        return this.clean(this._failedTaskCollectionName);
+    }
+
+    public cleanTask(): Promise<boolean> {
+        return this.clean(this._taskCollectionName);
+    }
+
+    public async hasTask(): Promise<boolean> {
+        let count = await this._db.collection(this._taskCollectionName).estimatedDocumentCount();
+        return count === 0;
+    }
+
+    public async hasFailedTask(): Promise<boolean> {
+        let count = await this._db.collection(this._failedTaskCollectionName).estimatedDocumentCount();
+        return count === 0;
+    }
+
+    private async push(collection: string, task: Task): Promise<boolean> {
+        await this._db.collection(collection).insertOne(Object.assign({ack: false}, task));
+        return Promise.resolve(true);
+    }
+
+    private async peek(collection: string): Promise<Task> {
+        const cursor = await this._db.collection(collection).findOneAndUpdate({ack: false}, {$set: {ack: true}});
+        return cursor.value;
+    }
+
+    private async clean(collection: string): Promise<boolean> {
+        await this._db.collection(collection).deleteMany({ack: true});
+        return true;
+    }
+}

--- a/src/task/task-orchestra.spec.ts
+++ b/src/task/task-orchestra.spec.ts
@@ -58,7 +58,7 @@ export class TaskOrchestraSpec {
                 res.subResources.push({
                     id: i * 100 + j,
                     retryCount: Math.round(Math.random() * 5),
-                    will_success: !!Math.round(Math.random() * 1)
+                    willSuccess: !!Math.round(Math.random() * 1)
                 });
             }
             fakeResources.push(res);

--- a/src/task/task-orchestra.ts
+++ b/src/task/task-orchestra.ts
@@ -55,6 +55,17 @@ export class TaskOrchestra {
                 return true;
             })
             .then((hasSomeTaskExecuted) => {
+                /* Need to ensure the list page is checked regularly */
+                if (Date.now() - this._lastMainTaskExeTime > this._config.minCheckInterval) {
+                    // force queue a MainTask
+                    this.queue(new CommonTask(TaskType.MAIN))
+                        .then(() => {
+                            this._timerId = setTimeout(() => {
+                                this.pick();
+                            }, actualInterval);
+                        });
+                    return;
+                }
                 /* Either task or failed task has been executed, we will try to pick again */
                 if (hasSomeTaskExecuted) {
                     this._timerId = setTimeout(() => {

--- a/src/task/task-orchestra.ts
+++ b/src/task/task-orchestra.ts
@@ -37,7 +37,7 @@ export class TaskOrchestra {
     }
 
     public async queue(task: Task): Promise<void> {
-        await this._taskStore.enqueueTask(task);
+        await this._taskStore.offerTask(task);
     }
 
     public stop() {
@@ -78,10 +78,10 @@ export class TaskOrchestra {
      */
     private async pickTask(): Promise<boolean> {
         if (await this._taskStore.hasTask()) {
-            let task = await this._taskStore.popTask();
+            let task = await this._taskStore.pollTask();
             let result = await this._scraper.executeTask(task);
             if (result === TaskStatus.NeedRetry) {
-                await this._taskStore.enqueueFailedTask(task);
+                await this._taskStore.offerFailedTask(task);
             } else if (result === TaskStatus.Success && task.type === TaskType.MAIN) {
                 this._lastMainTaskExeTime = Date.now();
             }
@@ -96,10 +96,10 @@ export class TaskOrchestra {
      */
     private async pickFailedTask(): Promise<boolean> {
         if (await this._taskStore.hasFailedTask()) {
-            let task = await this._taskStore.popFailedTask();
+            let task = await this._taskStore.pollFailedTask();
             let result = await this._scraper.executeTask(task);
             if (result === TaskStatus.NeedRetry) {
-                await this._taskStore.enqueueFailedTask(task);
+                await this._taskStore.offerFailedTask(task);
             }
             return true;
         }

--- a/src/task/task-status.ts
+++ b/src/task/task-status.ts
@@ -17,5 +17,5 @@
 export enum TaskStatus {
     Success,
     Fail,
-    NeedRetry,
+    NeedRetry
 }

--- a/src/task/task-status.ts
+++ b/src/task/task-status.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 IROHA LAB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export enum TaskStatus {
+    Success,
+    Fail,
+    NeedRetry,
+}

--- a/src/task/task-types.ts
+++ b/src/task/task-types.ts
@@ -25,6 +25,8 @@ export interface Task {
     id: number;
     type: TaskType;
     timestamp: number;
+    retryCount?: number;
+    updateTime?: number;
 }
 
 export class CommonTask implements Task {

--- a/src/task/task-types.ts
+++ b/src/task/task-types.ts
@@ -24,11 +24,14 @@ export enum TaskType {
 export interface Task {
     id: number;
     type: TaskType;
+    timestamp: number;
 }
 
 export class CommonTask implements Task {
     public id: number;
+    public timestamp: number;
     constructor(public type: TaskType) {
         this.id = taskCount++;
+        this.timestamp = Date.now();
     }
 }

--- a/src/test/fake-scraper.ts
+++ b/src/test/fake-scraper.ts
@@ -30,7 +30,7 @@ export interface FakeResource {
 
 export interface FakeSubResource {
     id: number;
-    will_success: boolean;
+    willSuccess: boolean;
     retryCount: number;
 }
 
@@ -70,7 +70,7 @@ export class FakeScraper implements Scraper {
 
     private async doExecuteSubTask(task: FakeTask): Promise<TaskStatus> {
         let payload = task.payload as FakeSubResource;
-        if (payload.will_success) {
+        if (payload.willSuccess) {
             this.resolvedIds.push({id: payload.id, timestamp: Date.now()});
             return TaskStatus.Success;
         } else if (payload.retryCount === 0) {

--- a/src/test/in-memory-item-store.ts
+++ b/src/test/in-memory-item-store.ts
@@ -20,7 +20,7 @@ import { Item } from '../entity/Item';
 import { ItemStorage } from '../types';
 
 @injectable()
-export class InMemoryStore<T> implements ItemStorage<T> {
+export class InMemoryItemStore<T> implements ItemStorage<T> {
     private _itemTable = new Map<T, Item<T>>();
     public deleteItem(id: T): Promise<boolean> {
         this._itemTable.delete(id);

--- a/src/test/in-memory-store.ts
+++ b/src/test/in-memory-store.ts
@@ -17,10 +17,10 @@
 import { injectable } from 'inversify';
 import { inspect } from 'util';
 import { Item } from '../entity/Item';
-import { PersistentStorage } from '../types';
+import { ItemStorage } from '../types';
 
 @injectable()
-export class InMemoryStore<T> implements PersistentStorage<T> {
+export class InMemoryStore<T> implements ItemStorage<T> {
     private _itemTable = new Map<T, Item<T>>();
     public deleteItem(id: T): Promise<boolean> {
         this._itemTable.delete(id);

--- a/src/test/in-memory-task-store.ts
+++ b/src/test/in-memory-task-store.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 IROHA LAB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { injectable } from 'inversify';
+import { Task } from '../task/task-types';
+import { TaskStorage } from '../types';
+
+@injectable()
+export class InMemoryTaskStore implements TaskStorage {
+    private _taskQueue: Task[];
+    private _failedTaskQueue: Task[];
+
+    constructor() {
+        this._taskQueue = [];
+        this._failedTaskQueue = [];
+    }
+
+    public offerFailedTask(task: Task): Promise<boolean> {
+        this._failedTaskQueue.push(task);
+        return Promise.resolve(true);
+    }
+
+    public offerTask(task: Task): Promise<boolean> {
+        this._taskQueue.push(task);
+        return Promise.resolve(true);
+    }
+
+    public hasFailedTask(): Promise<boolean> {
+        return Promise.resolve(this._failedTaskQueue.length !== 0);
+    }
+
+    public hasTask(): Promise<boolean> {
+        return Promise.resolve(this._taskQueue.length !== 0);
+    }
+
+    public pollFailedTask(): Promise<Task> {
+        return Promise.resolve(this._failedTaskQueue.shift());
+    }
+
+    public pollTask(): Promise<Task> {
+        return Promise.resolve(this._taskQueue.shift());
+    }
+
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,20 +19,30 @@ import { Task } from './task/task-types';
 
 export const TYPES = {
     ConfigLoader: Symbol.for('ConfigLoader'),
-    PersistentStorage: Symbol.for('PersistentStorage'),
+    ItemStorage: Symbol.for('ItemStorage'),
     Scraper: Symbol.for('Scraper'),
+    TaskStorage: Symbol.for('TaskStorage'),
     TaskTimingFactory: Symbol.for('TaskTiming')
 };
 
-export interface PersistentStorage<T> {
-    onStart(): Promise<void>;
-    onEnd(): Promise<void>;
+export interface ItemStorage<T> {
     deleteItem(id: T): Promise<boolean>;
     getItem(id: T): Promise<Item<T>|null>;
     hasItem(id: T): Promise<boolean>;
     filterItemNotStored(ids: T[]): Promise<T[]>;
     putItem(item: Item<T>): Promise<boolean>;
     searchItem(keyword: string): Promise<Array<Item<T>>>;
+}
+
+export interface TaskStorage {
+    enqueueTask(task: Task): Promise<boolean>;
+    getTask(task: Task): Promise<Task>;
+    enqueueFailedTask(task: Task): Promise<boolean>;
+    getFailedTask(task: Task): Promise<Task>;
+    cleanTask(): Promise<boolean>;
+    cleanFailedTask(): Promise<boolean>;
+    hasTask(): Promise<boolean>;
+    hasFailedTask(): Promise<boolean>;
 }
 
 export interface Scraper {

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@
  */
 
 import { Item } from './entity/Item';
+import { TaskStatus } from './task/task-status';
 import { Task } from './task/task-types';
 
 export const TYPES = {
@@ -36,11 +37,9 @@ export interface ItemStorage<T> {
 
 export interface TaskStorage {
     enqueueTask(task: Task): Promise<boolean>;
-    getTask(task: Task): Promise<Task>;
+    popTask(): Promise<Task>;
     enqueueFailedTask(task: Task): Promise<boolean>;
-    getFailedTask(task: Task): Promise<Task>;
-    cleanTask(): Promise<boolean>;
-    cleanFailedTask(): Promise<boolean>;
+    popFailedTask(): Promise<Task>;
     hasTask(): Promise<boolean>;
     hasFailedTask(): Promise<boolean>;
 }
@@ -48,7 +47,13 @@ export interface TaskStorage {
 export interface Scraper {
     start(): Promise<any>;
     end(): Promise<any>;
-    executeTask(task: Task): Promise<any>;
+
+    /**
+     * Execute the task.
+     * @param {Task} task
+     * @returns {Promise<boolean>} true, the
+     */
+    executeTask(task: Task): Promise<TaskStatus>;
 }
 
 export interface ConfigLoader {

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,10 +36,10 @@ export interface ItemStorage<T> {
 }
 
 export interface TaskStorage {
-    enqueueTask(task: Task): Promise<boolean>;
-    popTask(): Promise<Task>;
-    enqueueFailedTask(task: Task): Promise<boolean>;
-    popFailedTask(): Promise<Task>;
+    offerTask(task: Task): Promise<boolean>;
+    pollTask(): Promise<Task>;
+    offerFailedTask(task: Task): Promise<boolean>;
+    pollFailedTask(): Promise<Task>;
     hasTask(): Promise<boolean>;
     hasFailedTask(): Promise<boolean>;
 }


### PR DESCRIPTION
1. Change task management from the in-memory queue to MongoDB.
2. Add a failed task queue.
  when a task failed with retry needed, the task will move to the failed task queue.
  if the main task queue is empty, task orchestra will try to pick a task from the failed task queue.
