### PR TITLE
Fix Infinite Retry issue

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -41,6 +41,7 @@ export class ConfigManager implements ConfigLoader {
     private _minCheckInterval: number;
     private _maxPageNo: number;
     private _maxSearchCount: number;
+    private _maxRetryCount: number;
 
     public get mode(): string {
         return this._mode;
@@ -98,6 +99,10 @@ export class ConfigManager implements ConfigLoader {
         return this._maxSearchCount;
     }
 
+    public get maxRetryCount(): number {
+        return this._maxRetryCount;
+    }
+
     public load(): void {
         this._mode = process.env.INDEXER_MODE;
         if (!this._mode) {
@@ -120,5 +125,6 @@ export class ConfigManager implements ConfigLoader {
         this._minCheckInterval = parseInt(process.env.MIN_CHECK_INTERVAL, 10) || (15 * 60 * 1000);
         this._maxPageNo = parseInt(process.env.MAX_PAGE_NO, 10) || 5;
         this._maxSearchCount = parseInt(process.env.MAX_SEARCH_COUNT, 10) || 100;
+        this._maxRetryCount = parseInt(process.env.MAX_RETRY_COUNT, 10) || 5;
     }
 }

--- a/src/task/task-orchestra.ts
+++ b/src/task/task-orchestra.ts
@@ -110,6 +110,10 @@ export class TaskOrchestra {
     private async pickFailedTask(): Promise<boolean> {
         if (await this._taskStore.hasFailedTask()) {
             let task = await this._taskStore.pollFailedTask();
+            if (task.retryCount > this._config.maxRetryCount) {
+                // drop task
+                return false;
+            }
             let result = await this._scraper.executeTask(task);
             if (result === TaskStatus.NeedRetry) {
                 await this._taskStore.offerFailedTask(task);

--- a/src/test/fake-config.ts
+++ b/src/test/fake-config.ts
@@ -34,6 +34,7 @@ export class FakeConfigManager implements ConfigLoader {
     public maxPageNo: number;
     public maxSearchCount: number;
     public serverHost: string;
+    public maxRetryCount: number;
 
     public load(): void {
         this.mode = process.env.INDEXER_MODE;
@@ -57,5 +58,6 @@ export class FakeConfigManager implements ConfigLoader {
         this.minCheckInterval = parseInt(process.env.MIN_CHECK_INTERVAL, 10) || (15 * 60);
         this.maxPageNo = parseInt(process.env.MAX_PAGE_NO, 10) || 5;
         this.maxSearchCount = parseInt(process.env.MAX_SEARCH_COUNT, 10) || 100;
+        this.maxRetryCount = parseInt(process.env.MAX_RETRY_COUNT, 10) || 5;
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,5 +71,6 @@ export interface ConfigLoader {
     minCheckInterval: number; // for main task, unit is millisecond
     maxPageNo: number; // max page number for scrapping
     maxSearchCount: number; // max search result count
+    maxRetryCount: number; // max retry times for a task
     load(): void;
 }


### PR DESCRIPTION
I have observed an issue that sometimes, a source can return 500 that will cause a retry-able failed task which will be retried infinitely.
This PR is to fix this by leveraging the already added field `retryCount` in the task object to prevent a task from infinitely retrying.

A new configuration environment variable `MAX_RETRY_COUNT` is added with a default value 5.